### PR TITLE
Only configure selinux on systems where it is enabled

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -57,9 +57,11 @@ class podman::install (
     }
   }
 
-  selboolean { 'container_manage_cgroup':
-    persistent => true,
-    value      => on,
+  if $::selinux or $facts['os']['selinux']['enabled'] {
+    selboolean { 'container_manage_cgroup':
+      persistent => true,
+      value      => on,
+    }
   }
 
   file { '/etc/containers/nodocker':


### PR DESCRIPTION
Previously `podman::install` would unconditionally try to set an `selboolean`
even on systems where selinux is not available or not enabled. This would
cause an error when applying the catalog.

This commit makes managing the `selboolean` optional based on whether or
not `selinux` support is enabled according to the core puppet facts.

It checks both the legacy `selinux` fact and the modern `os.selinux.enabled` facts.
The way the structured fact is checked might break on systems which do not expose
selinux information in the `os` structured fact, however all supported versions of
puppet for all supported operating systems in metadata.json should provide this value.

Since this module reports to support stdlib as old as 4.1.0, it's not possible to
use the `fact('os.selinux.enabled')` function call which would cleanly handle the
`selinux` nested hash key being missing. Nor is the `dig` function available across
all supported puppet/stdlib versions. The completely safe alternative within the
version constraints would be the following, but this is an unholy mess:

```puppet
if $::selinux or (
    'os' in $facts
    and 'selinux' in $facts['os']
    and 'enabled' in $facts['os']['selinux']
    and $facts['os']['selinux']['enabled']) {}
```