### PR TITLE
Permit container flags without values

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -233,6 +233,9 @@ next puppet run.  This is achieved by storing the complete set of flags as
 a base64 encoded string in a container label named `puppet_resource_flags`
 so it can be compared with the assigned resource state.
 
+For flags which take no arguments, set the hash value to be undef. In the
+YAML representation you can use `~` or `null` as the value.
+
 Default value: `{}`
 
 ##### `service_flags`

--- a/manifests/container.pp
+++ b/manifests/container.pp
@@ -216,6 +216,8 @@ define podman::container (
       $_flags = $merged_flags.reduce('') |$mem, $flag| {
         if $flag[1] =~ String {
           "${mem} --${flag[0]} '${flag[1]}'"
+        } elsif $flag[1] =~ Undef {
+          "${mem} --${flag[0]}"
         } else {
           $dup = $flag[1].reduce('') |$mem2, $value| {
             "${mem2} --${flag[0]} '${value}'"


### PR DESCRIPTION
Some flags to the podman command don't take values (eg. `--privileged`).
This change makes it possible to use those flags from the Puppet module
and from hiera by setting the value of the flag to be undef.