### PR TITLE
Remove creation of pointless temp file

### DIFF
--- a/manifests/container.pp
+++ b/manifests/container.pp
@@ -178,8 +178,6 @@ define podman::container (
               [[ $? -ne 0 ]] && latest_digest=\$(skopeo inspect --no-creds docker://\${image_name} | \
                 /opt/puppetlabs/puppet/bin/ruby -rjson -e 'puts (JSON.parse(STDIN.read))["Digest"]')
               test -z "\${latest_digest}" && exit 0     # Do not update if unable to get latest digest
-              echo "running_digest: \${running_digest}" >/tmp/digest
-              echo "latest_digest: \${latest_digest}" >>/tmp/digest
               test "\${running_digest}" = "\${latest_digest}"
             fi
             |END


### PR DESCRIPTION
Exec["verify_container_image_x"] creates the temp file `/tmp/digest`
every time it runs. This file does not appear to be used for anything,
however. Presumably it is just some debugging code that was committed by
accident, so remove it.