### PR TITLE
Actually make podman-docker optional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,9 @@
 # @param podman_docker_pkg
 #   The name of the podman-docker package (default 'podman-docker')
 #
+# @param manage_podman_docker
+#   Set whether podmand-docker should be managed
+#
 # @param pods
 #   A hash of pods to manage using [`podman::pod`](#podmanpod)
 #
@@ -75,7 +78,8 @@
 class podman (
   String $podman_pkg,
   String $skopeo_pkg,
-  Optional[String] $podman_docker_pkg,
+  String $podman_docker_pkg,
+  Boolean $manage_podman_docker    = true,
   Boolean $manage_subuid           = false,
   Boolean $match_subuid_subgid     = true,
   String $file_header              = '# FILE MANAGED BY PUPPET',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -13,11 +13,11 @@
 class podman::install (
   String $podman_pkg                  = $podman::podman_pkg,
   String $skopeo_pkg                  = $podman::skopeo_pkg,
-  Optional[String] $podman_docker_pkg = $podman::podman_docker_pkg,
+  String $podman_docker_pkg = $podman::podman_docker_pkg,
 ){
   ensure_resource('Package', $podman_pkg, { 'ensure' => 'installed' })
   ensure_resource('Package', $skopeo_pkg, { 'ensure' => 'installed' })
-  if $podman_docker_pkg { ensure_resource('Package', $podman_docker_pkg, { 'ensure' => 'installed' }) }
+  if $podman::manage_podman_docker { ensure_resource('Package', $podman_docker_pkg, { 'ensure' => 'installed' }) }
 
   if $podman::manage_subuid {
     Concat { '/etc/subuid':


### PR DESCRIPTION
Before this change it was impossible to avoid installing `podman-docker` because even though the parameter was optional, the Hiera data provided the value and no way to undo that default.