### PR TITLE
selboolean requires package to be installed first

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -92,6 +92,7 @@ class podman::install (
     selboolean { 'container_manage_cgroup':
       persistent => true,
       value      => on,
+      require    => Package[$podman_pkg],
     }
   }
 


### PR DESCRIPTION
On some systems the container-selinux package might not already be installed.

The podman packages pull this in, but the selboolean won't exist until that's done.

This change ensures that the selboolean resource is applied _after_ the package is installed.