### PR TITLE
Shell extras

### DIFF
--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -26,9 +26,10 @@
 #
 define podman::image (
   String $image,
-  String $ensure  = 'present',
-  Hash $flags     = {},
-  String $user    = '',
+  String $ensure    = 'present',
+  Hash $flags       = {},
+  String $user      = '',
+  Hash $exec_extras = {},
 ){
   require podman::install
 
@@ -69,20 +70,20 @@ define podman::image (
       path        => '/sbin:/usr/sbin:/bin:/usr/bin',
     }
   }
-
+  $full_exec = $exec_defaults + $exec_extras
   case $ensure {
     'present': {
       Exec { "pull_image_${title}":
         command => "podman image pull ${_flags} ${image}",
         unless  => "podman image exists ${image}",
-        *       => $exec_defaults,
+        *       => $full_exec,
       }
     }
     'absent': {
       Exec { "pull_image_${title}":
         command => "podman image pull ${_flags} ${image}",
         unless  => "podman rmi ${image}",
-        *       => $exec_defaults,
+        *       => $full_exec,
       }
     }
     default: {


### PR DESCRIPTION
In some environments it is necessary to add some special tags for the Podman Image download. In our Case we've to set a specail Proxy Enviornment Variable. This Patch adds the possibilty to add this
For example:
`
podman::image { 'image':
  image => image,
  flags => {
    authfile => '/root/auth.json',
  },
  exec_extras => {
    environment => [
      "HTTP_PROXY=http://${proxy_fqdn}:3128",
      "HTTPS_PROXY=http://${proxy_fqdn}:3128",
    ],
 },
}
`