### PR TITLE
Don't check for upstream image if current image matches desired

### DIFF
--- a/manifests/container.pp
+++ b/manifests/container.pp
@@ -203,10 +203,11 @@ define podman::container (
               then
               running=\$(podman container inspect ${container_name} --format '{{.ImageName}}' | awk -F/ '{print \$NF}')
               declared=\$(echo "${image}" | awk -F/ '{print \$NF}')
+              test "\${running}" = "\${declared}" && exit 0
               available=\$(skopeo inspect docker://${image} | \
                 /opt/puppetlabs/puppet/bin/ruby -rjson -e 'puts (JSON.parse(STDIN.read))["Name"]')
               test -z "\${available}" && exit 0     # Do not update update if unable to get the new image
-              test "\${running}" = "\${declared}"
+              exit 1
             fi
             |END
           notify   => [


### PR DESCRIPTION
If the running image and the desired image match and update is false, there is no reason to check the manifest of the image in the repository. Doing so hits the docker hub limits even when no change is needed.

Fixes #26 