### PR TITLE
Include sbin in path when running podman network command

### DIFF
--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -107,14 +107,14 @@ define podman::network (
                     ${_gateway} ${_internal} ${_ip_range} ${_labels} ${_subnet} ${_ipv6}"
                    |END
         unless  => "podman network exists ${title}",
-        path    => ['/usr/bin', '/bin']
+        path    => ['/usr/bin', '/bin', '/usr/sbin', '/sbin']
       }
     }
     'absent': {
       exec { "podman_remove_volume_${title}":
         command => "podman network rm ${title}",
         onlyif  => "podman network exists ${title}",
-        path    => ['/usr/bin', '/bin']
+        path    => ['/usr/bin', '/bin', '/usr/sbin', '/sbin']
       }
     }
     default: {

--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -104,7 +104,7 @@ define podman::network (
       exec { "podman_create_network_${title}":
         command => @("END"/L),
                    podman network create ${title} --driver ${driver} ${_opts} \
-                    ${_gateway} ${_internal} ${_ip_range} ${_labels} ${_subnet} ${_ipv6}"
+                    ${_gateway} ${_internal} ${_ip_range} ${_labels} ${_subnet} ${_ipv6}
                    |END
         unless  => "podman network exists ${title}",
         path    => ['/usr/bin', '/bin', '/usr/sbin', '/sbin']


### PR DESCRIPTION
When running `podman network` commands, if the selected storage driver
relies in an executable in the PATH, then the podman command must
be run with that executable available. In the case of ZFS storage
driver, the `zfs` binary may be in /usr/sbin, so this commit adds
the sbin directories to the PATHs.

In all other places in the module, the PATH is set to include both
bin and sbin directories, the podman::network defined type is the
only place I could find where sbin was missing.

Also strips an errant double quote which was introduced during a refactoring.