### PR TITLE
Add search expression to the user resource collector

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -137,7 +137,7 @@ class podman (
     unless defined(Podman::Rootless[$user]) {
       podman::rootless { $user: }
     }
-  }
 
-  User <||> -> Podman::Rootless <||>
+    User <| title == $user |> -> Podman::Rootless <| title == $user |>
+  }
 }


### PR DESCRIPTION
Hello,

Resources collectors are used in this module to define ordering, e.g. create users before podman rootless definitions.
The resource collectors used here will collect all available definitions though, which is a problem in a puppet tree with virtual (user) resources as the collector will attempt to create all of them.

Therefore, in this pull request, I propose to add a search expression to the resource collectors in order to only consider resources for the required users.

Thx,
Jan