### PR TITLE
Bump dependency versions for concat and stdlib

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.1.0 <= 7.0.0"
+      "version_requirement": ">= 4.1.0 <= 8.1.0"
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 2.1.0 <= 7.0.0"
+      "version_requirement": ">= 2.1.0 <= 8.0.0"
     },
     {
       "name": "puppetlabs/selinux_core",


### PR DESCRIPTION
Both modules have been out for a while and pose no compatibility issues as far as I can see/test:
* <https://forge.puppet.com/modules/puppetlabs/stdlib/8.1.0>
* <https://forge.puppet.com/modules/puppetlabs/concat/7.1.1>