### PR TITLE
Start user.slice if not running before trying to use systemctl --user

### DIFF
--- a/manifests/container.pp
+++ b/manifests/container.pp
@@ -111,6 +111,7 @@ define podman::container (
       environment => [
         "HOME=${User[$user]['home']}",
         "XDG_RUNTIME_DIR=/run/user/${User[$user]['uid']}",
+        "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${User[$user]['uid']}/bus",
       ],
       cwd         => User[$user]['home'],
       user        => $user,

--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -61,6 +61,7 @@ define podman::image (
       environment => [
           "HOME=${User[$user]['home']}",
           "XDG_RUNTIME_DIR=/run/user/${User[$user]['uid']}",
+          "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${User[$user]['uid']}/bus",
         ] + $exec_env,
       cwd         => User[$user]['home'],
       provider    => 'shell',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,9 @@
 # @param compose_pkg
 #   The name of the podman-compose package (default 'podman-compose').
 #
+# @param machienectl_pkg
+#   The name of the machienectl package (default 'systemd-container').
+#
 # @param buildah_pkg_ensure
 #   The ensure value for the buildah package (default 'absent')
 #
@@ -23,6 +26,9 @@
 #
 # @param compose_pkg_ensure
 #   The ensure value for the podman-compose package (default 'absent')
+#
+# @param machienectl_pkg_ensure
+#   The ensure value for the machienectl package (default 'installed')
 #
 # @param nodocker
 #   Should the module create the `/etc/containers/nodocker` file to quiet Docker CLI messages.
@@ -105,9 +111,11 @@ class podman (
   String $buildah_pkg                                   = 'buildah',
   String $podman_docker_pkg                             = 'podman-docker',
   String $compose_pkg                                   = 'podman-compose',
+  String $machienectl_pkg                               = 'systemd-container',
   Enum['absent', 'installed'] $buildah_pkg_ensure       = 'absent',
   Enum['absent', 'installed'] $podman_docker_pkg_ensure = 'installed',
   Enum['absent', 'installed'] $compose_pkg_ensure       = 'absent',
+  Enum['absent', 'installed'] $machienectl_pkg_ensure   = 'installed',
   Enum['absent', 'file'] $nodocker                      = 'absent',
   Hash $storage_options                                 = {},
   Array $rootless_users                                 = [],

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,6 +7,7 @@ class podman::install {
   ensure_resource('Package', $podman::buildah_pkg, { 'ensure' => $podman::buildah_pkg_ensure })
   ensure_resource('Package', $podman::podman_docker_pkg, { 'ensure' => $podman::podman_docker_pkg_ensure })
   ensure_resource('Package', $podman::compose_pkg, { 'ensure' => $podman::compose_pkg_ensure })
+  ensure_resource('Package', $podman::machienectl_pkg, { 'ensure' => $podman::machienectl_pkg_ensure })
 
   if $podman::manage_subuid {
     concat { ['/etc/subuid', '/etc/subgid']:

--- a/manifests/pod.pp
+++ b/manifests/pod.pp
@@ -54,6 +54,7 @@ define podman::pod (
       environment => [
         "HOME=${User[$user]['home']}",
         "XDG_RUNTIME_DIR=/run/user/${User[$user]['uid']}",
+        "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${User[$user]['uid']}/bus",
       ],
       cwd         => User[$user]['home'],
       provider    => 'shell',

--- a/manifests/rootless.pp
+++ b/manifests/rootless.pp
@@ -7,6 +7,7 @@ define podman::rootless {
     provider => 'shell',
     unless   => "test $(loginctl show-user ${name} --property=Linger) = 'Linger=yes'",
     require  => User[$name],
+    notify   => Service['systemd-logind'],
   }
   ensure_resource('Service', 'systemd-logind', { ensure => 'running', enable => true } )
 
@@ -24,13 +25,25 @@ define podman::rootless {
     }
   )
 
+  exec { "start_${name}.slice":
+    path     => $facts['path'],
+    command  => "machinectl shell ${name}@.host '/bin/true'",
+    unless   => "systemctl is-active user-${User[$name]['uid']}.slice",
+    require  => [Exec["loginctl_linger_${name}"], Service['systemd-logind'], File["${User[$name]['home']}/.config/systemd/user"],],
+  }
+
   if $podman::enable_api_socket {
     exec { "podman rootless api socket ${name}":
-      command => "/bin/bash -c 'XDG_RUNTIME_DIR=/run/user/$( id -u ) systemctl --user enable --now podman.socket'",
-      path    => '/bin:/usr/bin',
-      user    => $name,
-      unless  => "/bin/bash -c 'XDG_RUNTIME_DIR=/run/user/$( id -u ) systemctl --user status podman.socket'",
-      require => Exec["loginctl_linger_${name}"],
+      command     => 'systemctl --user enable --now podman.socket',
+      path        => '/bin:/usr/bin',
+      user        => $name,
+      environment => [
+        "HOME=${User[$name]['home']}",
+        "XDG_RUNTIME_DIR=/run/user/${User[$name]['uid']}",
+        "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${User[$name]['uid']}/bus",
+      ],
+      unless      => 'systemctl --user status podman.socket',
+      require     => [Exec["loginctl_linger_${name}"], Exec["start_${name}.slice"], ],
     }
   }
 }

--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -51,6 +51,7 @@ define podman::volume (
       environment => [
         "HOME=${User[$user]['home']}",
         "XDG_RUNTIME_DIR=/run/user/${User[$user]['uid']}",
+        "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${User[$user]['uid']}/bus",
       ],
       cwd         => User[$user]['home'],
       provider    => 'shell',

--- a/spec/classes/podman_spec.rb
+++ b/spec/classes/podman_spec.rb
@@ -9,6 +9,7 @@ describe 'podman' do
           podman_pkg: 'podman',
           skopeo_pkg: 'skopeo',
           buildah_pkg: 'buildah',
+          machienectl_pkg: 'machienectl',
           buildah_pkg_ensure: 'installed',
           podman_docker_pkg: 'podman-docker',
           podman_docker_pkg_ensure: 'installed',


### PR DESCRIPTION
On my highly stripped down hosts, starting the user systemd session seems to be required before the `systemctl --user` commands will work.