### PR TITLE
Check for the container to avoid refresh errors

### DIFF
--- a/manifests/container.pp
+++ b/manifests/container.pp
@@ -245,6 +245,7 @@ define podman::container (
                        ${systemctl} stop podman-${container_name} || podman container stop --time 60 ${container_name}
                        podman container rm --force ${container_name}
                        |END
+        onlyif      => "${systemctl} is-active podman-${container_name}",
         refreshonly => true,
         notify      => Exec["podman_create_${handle}"],
         require     => $requires,


### PR DESCRIPTION
If you've got a class that contains a container and the class gets notified during the initial run, the container doesn't exist yet.

This should clean up some unexpected errors from complex refresh chains.