### PR TITLE
Add user option for networks

### DIFF
--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -32,6 +32,11 @@
 # @param ipv6
 #   Enable IPv6 (dual-stack) networking.
 #
+# @param user
+#   Optional user for creating rootless container networks.  For rootless containers,
+#   the user must also be defined as a puppet resource that includes at least
+#   'uid', 'gid', and 'home' attributes.
+#
 # @example
 #   podman::network { 'mnetwork':
 #     driver   => 'bridge',
@@ -49,6 +54,7 @@ define podman::network (
   Hash[String,String] $labels = {},
   Optional[String] $subnet = undef,
   Boolean $ipv6 = false,
+  String $user           = '',
 ) {
   require podman::install
 
@@ -99,22 +105,47 @@ define podman::network (
     default => '',
   }
 
+  # A rootless container network will be defined as the defined user
+  if $user != '' {
+    # Set default execution environment for the rootless user
+    $exec_defaults = {
+      user => $user,
+      environment => [
+        "HOME=${User[$user]['home']}",
+        "XDG_RUNTIME_DIR=/run/user/${User[$user]['uid']}",
+        "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${User[$user]['uid']}/bus",
+      ],
+      cwd         => User[$user]['home'],
+    }
+    $requires = [
+      Podman::Rootless[$user],
+      Service['podman systemd-logind'],
+    ]
+  } else {
+    $exec_defaults = {}
+    $requires = []
+  }
+
   case $ensure {
     'present': {
       exec { "podman_create_network_${title}":
         command => @("END"/L),
-                   podman network create ${title} --driver ${driver} ${_opts} \
+                  podman network create ${title} --driver ${driver} ${_opts} \
                     ${_gateway} ${_internal} ${_ip_range} ${_labels} ${_subnet} ${_ipv6}
-                   |END
+                  |END
         unless  => "podman network exists ${title}",
-        path    => ['/usr/bin', '/bin', '/usr/sbin', '/sbin']
+        path    => ['/usr/bin', '/bin', '/usr/sbin', '/sbin'],
+        require => $requires,
+        *       => $exec_defaults,
       }
     }
     'absent': {
       exec { "podman_remove_volume_${title}":
         command => "podman network rm ${title}",
         onlyif  => "podman network exists ${title}",
-        path    => ['/usr/bin', '/bin', '/usr/sbin', '/sbin']
+        path    => ['/usr/bin', '/bin', '/usr/sbin', '/sbin'],
+        require => $requires,
+        *       => $exec_defaults,
       }
     }
     default: {
@@ -122,4 +153,3 @@ define podman::network (
     }
   }
 }
-


### PR DESCRIPTION
This adds a `user` option to the `podman::network` type, allowing creation of networks as non-root users.

The logic was largely copied from `container`, and seems to work for my basic test.

Fixes #52 