### PR TITLE
Update install.pp due to false positive on selinux check

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -40,7 +40,7 @@ class podman::install {
     }
   }
 
-  if $::selinux or $facts['os']['selinux']['enabled'] {
+  if $::selinux == true or $facts['os']['selinux']['enabled'] == true {
     selboolean { 'container_manage_cgroup':
       persistent => true,
       value      => on,


### PR DESCRIPTION
Get the following error when running the podman on RHEL 8.6 with selinux disabled. Issue is resolved when we explicitly specify that the value should be the boolean true.

`Error: /Stage[main]/Podman::Install/Selboolean[container_manage_cgroup]: Could not evaluate: Execution of '/usr/sbin/getsebool container_manage_cgroup' returned 1: /usr/sbin/getsebool:  SELinux is disabled
Notice: /Stage[main]/Podman::Service/Service[podman.socket]: Dependency Selboolean[container_manage_cgroup] has failures: true
Warning: /Stage[main]/Podman::Service/Service[podman.socket]: Skipping because of failed dependencies`


facter -p os
{
  architecture => "x86_64",
  distro => {
    codename => "Ootpa",
    description => "Red Hat Enterprise Linux release 8.6 (Ootpa)",
    id => "RedHatEnterprise",
    release => {
      full => "8.6",
      major => "8",
      minor => "6"
    },
    specification => ":core-4.1-amd64:core-4.1-noarch"
  },
  family => "RedHat",
  hardware => "x86_64",
  name => "RedHat",
  release => {
    full => "8.6",
    major => "8",
    minor => "6"
  },
  selinux => {
    enabled => false
  }
}


facter -p selinux
false