### PR TITLE
Add support for deploying pods with containers

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -18,14 +18,14 @@
 
 ### Defined types
 
-* [`podman::container`](#podmancontainer): manage podman container and register as a systemd service
-* [`podman::image`](#podmanimage): pull or remove container images
-* [`podman::network`](#podmannetwork): Create a podman network with defined flags
-* [`podman::pod`](#podmanpod): Create a podman pod with defined flags
-* [`podman::rootless`](#podmanrootless): Enable a given user to run rootless podman containers as a systemd user service.
-* [`podman::subgid`](#podmansubgid): Define an entry in the `/etc/subgid` file.
-* [`podman::subuid`](#podmansubuid): Manage entries in `/etc/subuid`
-* [`podman::volume`](#podmanvolume): Create a podman volume with defined flags
+* [`podman::container`](#podman--container): manage podman container and register as a systemd service
+* [`podman::image`](#podman--image): pull or remove container images
+* [`podman::network`](#podman--network): Create a podman network with defined flags
+* [`podman::pod`](#podman--pod): Create a podman pod with defined flags and containers.
+* [`podman::rootless`](#podman--rootless): Enable a given user to run rootless podman containers as a systemd user service.
+* [`podman::subgid`](#podman--subgid): Define an entry in the `/etc/subgid` file.
+* [`podman::subuid`](#podman--subuid): Manage entries in `/etc/subuid`
+* [`podman::volume`](#podman--volume): Create a podman volume with defined flags
 
 ## Classes
 
@@ -72,31 +72,31 @@ podman::containers:
 
 The following parameters are available in the `podman` class:
 
-* [`podman_pkg`](#podman_pkg)
-* [`skopeo_pkg`](#skopeo_pkg)
-* [`buildah_pkg`](#buildah_pkg)
-* [`podman_docker_pkg`](#podman_docker_pkg)
-* [`compose_pkg`](#compose_pkg)
-* [`machinectl_pkg`](#machinectl_pkg)
-* [`buildah_pkg_ensure`](#buildah_pkg_ensure)
-* [`podman_docker_pkg_ensure`](#podman_docker_pkg_ensure)
-* [`compose_pkg_ensure`](#compose_pkg_ensure)
-* [`machinectl_pkg_ensure`](#machinectl_pkg_ensure)
-* [`nodocker`](#nodocker)
-* [`storage_options`](#storage_options)
-* [`rootless_users`](#rootless_users)
-* [`enable_api_socket`](#enable_api_socket)
-* [`manage_subuid`](#manage_subuid)
-* [`file_header`](#file_header)
-* [`match_subuid_subgid`](#match_subuid_subgid)
-* [`subid`](#subid)
-* [`pods`](#pods)
-* [`volumes`](#volumes)
-* [`images`](#images)
-* [`containers`](#containers)
-* [`networks`](#networks)
+* [`podman_pkg`](#-podman--podman_pkg)
+* [`skopeo_pkg`](#-podman--skopeo_pkg)
+* [`buildah_pkg`](#-podman--buildah_pkg)
+* [`podman_docker_pkg`](#-podman--podman_docker_pkg)
+* [`compose_pkg`](#-podman--compose_pkg)
+* [`machinectl_pkg`](#-podman--machinectl_pkg)
+* [`buildah_pkg_ensure`](#-podman--buildah_pkg_ensure)
+* [`podman_docker_pkg_ensure`](#-podman--podman_docker_pkg_ensure)
+* [`compose_pkg_ensure`](#-podman--compose_pkg_ensure)
+* [`machinectl_pkg_ensure`](#-podman--machinectl_pkg_ensure)
+* [`nodocker`](#-podman--nodocker)
+* [`storage_options`](#-podman--storage_options)
+* [`rootless_users`](#-podman--rootless_users)
+* [`enable_api_socket`](#-podman--enable_api_socket)
+* [`manage_subuid`](#-podman--manage_subuid)
+* [`file_header`](#-podman--file_header)
+* [`match_subuid_subgid`](#-podman--match_subuid_subgid)
+* [`subid`](#-podman--subid)
+* [`pods`](#-podman--pods)
+* [`volumes`](#-podman--volumes)
+* [`images`](#-podman--images)
+* [`containers`](#-podman--containers)
+* [`networks`](#-podman--networks)
 
-##### <a name="podman_pkg"></a>`podman_pkg`
+##### <a name="-podman--podman_pkg"></a>`podman_pkg`
 
 Data type: `String`
 
@@ -104,7 +104,7 @@ The name of the podman package (default 'podman')
 
 Default value: `'podman'`
 
-##### <a name="skopeo_pkg"></a>`skopeo_pkg`
+##### <a name="-podman--skopeo_pkg"></a>`skopeo_pkg`
 
 Data type: `String`
 
@@ -112,7 +112,7 @@ The name of the skopeo package (default 'skopeo')
 
 Default value: `'skopeo'`
 
-##### <a name="buildah_pkg"></a>`buildah_pkg`
+##### <a name="-podman--buildah_pkg"></a>`buildah_pkg`
 
 Data type: `String`
 
@@ -120,7 +120,7 @@ The name of the buildah package (default 'buildah')
 
 Default value: `'buildah'`
 
-##### <a name="podman_docker_pkg"></a>`podman_docker_pkg`
+##### <a name="-podman--podman_docker_pkg"></a>`podman_docker_pkg`
 
 Data type: `String`
 
@@ -128,7 +128,7 @@ The name of the podman-docker package (default 'podman-docker').
 
 Default value: `'podman-docker'`
 
-##### <a name="compose_pkg"></a>`compose_pkg`
+##### <a name="-podman--compose_pkg"></a>`compose_pkg`
 
 Data type: `String`
 
@@ -136,7 +136,7 @@ The name of the podman-compose package (default 'podman-compose').
 
 Default value: `'podman-compose'`
 
-##### <a name="machinectl_pkg"></a>`machinectl_pkg`
+##### <a name="-podman--machinectl_pkg"></a>`machinectl_pkg`
 
 Data type: `String`
 
@@ -144,7 +144,7 @@ The name of the machinectl package (default 'systemd-container').
 
 Default value: `'systemd-container'`
 
-##### <a name="buildah_pkg_ensure"></a>`buildah_pkg_ensure`
+##### <a name="-podman--buildah_pkg_ensure"></a>`buildah_pkg_ensure`
 
 Data type: `Enum['absent', 'installed']`
 
@@ -152,7 +152,7 @@ The ensure value for the buildah package (default 'absent')
 
 Default value: `'absent'`
 
-##### <a name="podman_docker_pkg_ensure"></a>`podman_docker_pkg_ensure`
+##### <a name="-podman--podman_docker_pkg_ensure"></a>`podman_docker_pkg_ensure`
 
 Data type: `Enum['absent', 'installed']`
 
@@ -160,7 +160,7 @@ The ensure value for the podman docker package (default 'installed')
 
 Default value: `'installed'`
 
-##### <a name="compose_pkg_ensure"></a>`compose_pkg_ensure`
+##### <a name="-podman--compose_pkg_ensure"></a>`compose_pkg_ensure`
 
 Data type: `Enum['absent', 'installed']`
 
@@ -168,7 +168,7 @@ The ensure value for the podman-compose package (default 'absent')
 
 Default value: `'absent'`
 
-##### <a name="machinectl_pkg_ensure"></a>`machinectl_pkg_ensure`
+##### <a name="-podman--machinectl_pkg_ensure"></a>`machinectl_pkg_ensure`
 
 Data type: `Enum['absent', 'installed']`
 
@@ -176,7 +176,7 @@ The ensure value for the machinectl package (default 'installed')
 
 Default value: `'installed'`
 
-##### <a name="nodocker"></a>`nodocker`
+##### <a name="-podman--nodocker"></a>`nodocker`
 
 Data type: `Enum['absent', 'file']`
 
@@ -185,7 +185,7 @@ Values should be either 'file' or 'absent'. (default is 'absent')
 
 Default value: `'absent'`
 
-##### <a name="storage_options"></a>`storage_options`
+##### <a name="-podman--storage_options"></a>`storage_options`
 
 Data type: `Hash`
 
@@ -193,7 +193,7 @@ A hash containing any storage options you wish to set in /etc/containers/storage
 
 Default value: `{}`
 
-##### <a name="rootless_users"></a>`rootless_users`
+##### <a name="-podman--rootless_users"></a>`rootless_users`
 
 Data type: `Array`
 
@@ -201,15 +201,15 @@ An array of users to manage using [`podman::rootless`](#podmanrootless)
 
 Default value: `[]`
 
-##### <a name="enable_api_socket"></a>`enable_api_socket`
+##### <a name="-podman--enable_api_socket"></a>`enable_api_socket`
 
 Data type: `Boolean`
 
 The enable value of the API socket (default `false`)
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="manage_subuid"></a>`manage_subuid`
+##### <a name="-podman--manage_subuid"></a>`manage_subuid`
 
 Data type: `Boolean`
 
@@ -218,9 +218,9 @@ The implementation uses [concat](https://forge.puppet.com/puppetlabs/concat) fra
 out the subuid/subgid entries.  If you have a large number of entries you may want to manage them
 with another method.  You cannot use the `subuid` and `subgid` defined types unless this is `true`.
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="file_header"></a>`file_header`
+##### <a name="-podman--file_header"></a>`file_header`
 
 Data type: `String`
 
@@ -229,7 +229,7 @@ Default file_header is `# FILE MANAGED BY PUPPET`
 
 Default value: `'# FILE MANAGED BY PUPPET'`
 
-##### <a name="match_subuid_subgid"></a>`match_subuid_subgid`
+##### <a name="-podman--match_subuid_subgid"></a>`match_subuid_subgid`
 
 Data type: `Boolean`
 
@@ -237,9 +237,9 @@ Enable the `subid` parameter to manage both subuid and subgid entries with the s
 This setting requires `manage_subuid` to be `true` or it will have no effect.
 (default is true)
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="subid"></a>`subid`
+##### <a name="-podman--subid"></a>`subid`
 
 Data type: `Hash`
 
@@ -249,7 +249,7 @@ Hash key `subuid` is the subordinate UID, and `count` is the number of subordina
 
 Default value: `{}`
 
-##### <a name="pods"></a>`pods`
+##### <a name="-podman--pods"></a>`pods`
 
 Data type: `Hash`
 
@@ -257,7 +257,7 @@ A hash of pods to manage using [`podman::pod`](#podmanpod)
 
 Default value: `{}`
 
-##### <a name="volumes"></a>`volumes`
+##### <a name="-podman--volumes"></a>`volumes`
 
 Data type: `Hash`
 
@@ -265,7 +265,7 @@ A hash of volumes to manage using [`podman::volume`](#podmanvolume)
 
 Default value: `{}`
 
-##### <a name="images"></a>`images`
+##### <a name="-podman--images"></a>`images`
 
 Data type: `Hash`
 
@@ -273,7 +273,7 @@ A hash of images to manage using [`podman::image`](#podmanimage)
 
 Default value: `{}`
 
-##### <a name="containers"></a>`containers`
+##### <a name="-podman--containers"></a>`containers`
 
 Data type: `Hash`
 
@@ -281,7 +281,7 @@ A hash of containers to manage using [`podman::container`](#podmancontainer)
 
 Default value: `{}`
 
-##### <a name="networks"></a>`networks`
+##### <a name="-podman--networks"></a>`networks`
 
 Data type: `Hash`
 
@@ -291,7 +291,7 @@ Default value: `{}`
 
 ## Defined types
 
-### <a name="podmancontainer"></a>`podman::container`
+### <a name="podman--container"></a>`podman::container`
 
 manage podman container and register as a systemd service
 
@@ -318,17 +318,18 @@ podman::container { 'jenkins':
 
 The following parameters are available in the `podman::container` defined type:
 
-* [`image`](#image)
-* [`user`](#user)
-* [`flags`](#flags)
-* [`service_flags`](#service_flags)
-* [`command`](#command)
-* [`ensure`](#ensure)
-* [`enable`](#enable)
-* [`update`](#update)
-* [`ruby`](#ruby)
+* [`image`](#-podman--container--image)
+* [`user`](#-podman--container--user)
+* [`pod`](#-podman--container--pod)
+* [`flags`](#-podman--container--flags)
+* [`service_flags`](#-podman--container--service_flags)
+* [`command`](#-podman--container--command)
+* [`ensure`](#-podman--container--ensure)
+* [`enable`](#-podman--container--enable)
+* [`update`](#-podman--container--update)
+* [`ruby`](#-podman--container--ruby)
 
-##### <a name="image"></a>`image`
+##### <a name="-podman--container--image"></a>`image`
 
 Data type: `String`
 
@@ -337,7 +338,7 @@ Container registry source of the image being deployed.  Required when
 
 Default value: `''`
 
-##### <a name="user"></a>`user`
+##### <a name="-podman--container--user"></a>`user`
 
 Data type: `String`
 
@@ -347,7 +348,16 @@ the user must also be defined as a puppet resource that includes at least
 
 Default value: `''`
 
-##### <a name="flags"></a>`flags`
+##### <a name="-podman--container--pod"></a>`pod`
+
+Data type: `String`
+
+This parameter is used by the podman::pod resource and should never be used
+directly.
+
+Default value: `''`
+
+##### <a name="-podman--container--flags"></a>`flags`
 
 Data type: `Hash`
 
@@ -365,7 +375,7 @@ YAML representation you can use `~` or `null` as the value.
 
 Default value: `{}`
 
-##### <a name="service_flags"></a>`service_flags`
+##### <a name="-podman--container--service_flags"></a>`service_flags`
 
 Data type: `Hash`
 
@@ -376,7 +386,7 @@ only the long form of the flag names.
 
 Default value: `{}`
 
-##### <a name="command"></a>`command`
+##### <a name="-podman--container--command"></a>`command`
 
 Data type: `String`
 
@@ -384,7 +394,7 @@ Optional command to be used as the container entry point.
 
 Default value: `''`
 
-##### <a name="ensure"></a>`ensure`
+##### <a name="-podman--container--ensure"></a>`ensure`
 
 Data type: `String`
 
@@ -392,16 +402,16 @@ Valid values are 'present' or 'absent'
 
 Default value: `'present'`
 
-##### <a name="enable"></a>`enable`
+##### <a name="-podman--container--enable"></a>`enable`
 
 Data type: `Boolean`
 
 Status of the automatically generated systemd service for the container.
-Valid values are 'running' or 'stopped'.
+Valid values are 'running' or 'stopped'. This is ignored if pod is set.
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="update"></a>`update`
+##### <a name="-podman--container--update"></a>`update`
 
 Data type: `Boolean`
 
@@ -411,9 +421,9 @@ value of the running container image with the digest of the registry image.
 When `false`, the container will only be redeployed when the declared state
 of the puppet resource is changed.
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="ruby"></a>`ruby`
+##### <a name="-podman--container--ruby"></a>`ruby`
 
 Data type: `Stdlib::Unixpath`
 
@@ -421,9 +431,15 @@ The absolute path to the ruby binary to use in scripts. The default path is
 '/opt/puppetlabs/puppet/bin/ruby' for Puppetlabs packaged puppet, and
 '/usr/bin/ruby' for all others.
 
-Default value: `$facts['ruby']['sitedir']`
+Default value:
 
-### <a name="podmanimage"></a>`podman::image`
+```puppet
+$facts['ruby']['sitedir'] ? {
+    /^\/opt\/puppetlabs\// => '/opt/puppetlabs/puppet/bin/ruby',
+    default                => '/usr/bin/ruby'
+```
+
+### <a name="podman--image"></a>`podman::image`
 
 pull or remove container images
 
@@ -444,20 +460,20 @@ podman::image { 'my_container':
 
 The following parameters are available in the `podman::image` defined type:
 
-* [`image`](#image)
-* [`ensure`](#ensure)
-* [`flags`](#flags)
-* [`user`](#user)
-* [`exec_env`](#exec_env)
+* [`image`](#-podman--image--image)
+* [`ensure`](#-podman--image--ensure)
+* [`flags`](#-podman--image--flags)
+* [`user`](#-podman--image--user)
+* [`exec_env`](#-podman--image--exec_env)
 
-##### <a name="image"></a>`image`
+##### <a name="-podman--image--image"></a>`image`
 
 Data type: `String`
 
 The name of the container image to pull, which should be present in a
 configured container registry.
 
-##### <a name="ensure"></a>`ensure`
+##### <a name="-podman--image--ensure"></a>`ensure`
 
 Data type: `String`
 
@@ -465,7 +481,7 @@ State of the resource must be either `present` or `absent`.
 
 Default value: `'present'`
 
-##### <a name="flags"></a>`flags`
+##### <a name="-podman--image--flags"></a>`flags`
 
 Data type: `Hash`
 
@@ -474,7 +490,7 @@ long form of the flag name.
 
 Default value: `{}`
 
-##### <a name="user"></a>`user`
+##### <a name="-podman--image--user"></a>`user`
 
 Data type: `String`
 
@@ -484,7 +500,7 @@ the user must also be defined as a Puppet resource and must include the
 
 Default value: `''`
 
-##### <a name="exec_env"></a>`exec_env`
+##### <a name="-podman--image--exec_env"></a>`exec_env`
 
 Data type: `Array`
 
@@ -494,7 +510,7 @@ pulled.  Useful for defining a proxy for downloads. For example:
 
 Default value: `[]`
 
-### <a name="podmannetwork"></a>`podman::network`
+### <a name="podman--network"></a>`podman::network`
 
 Create a podman network with defined flags
 
@@ -513,19 +529,19 @@ podman::network { 'mnetwork':
 
 The following parameters are available in the `podman::network` defined type:
 
-* [`ensure`](#ensure)
-* [`disable_dns`](#disable_dns)
-* [`driver`](#driver)
-* [`opts`](#opts)
-* [`gateway`](#gateway)
-* [`internal`](#internal)
-* [`ip_range`](#ip_range)
-* [`labels`](#labels)
-* [`subnet`](#subnet)
-* [`ipv6`](#ipv6)
-* [`user`](#user)
+* [`ensure`](#-podman--network--ensure)
+* [`disable_dns`](#-podman--network--disable_dns)
+* [`driver`](#-podman--network--driver)
+* [`opts`](#-podman--network--opts)
+* [`gateway`](#-podman--network--gateway)
+* [`internal`](#-podman--network--internal)
+* [`ip_range`](#-podman--network--ip_range)
+* [`labels`](#-podman--network--labels)
+* [`subnet`](#-podman--network--subnet)
+* [`ipv6`](#-podman--network--ipv6)
+* [`user`](#-podman--network--user)
 
-##### <a name="ensure"></a>`ensure`
+##### <a name="-podman--network--ensure"></a>`ensure`
 
 Data type: `Enum['present', 'absent']`
 
@@ -533,16 +549,16 @@ State of the resource must be either 'present' or 'absent'.
 
 Default value: `'present'`
 
-##### <a name="disable_dns"></a>`disable_dns`
+##### <a name="-podman--network--disable_dns"></a>`disable_dns`
 
 Data type: `Boolean`
 
 Disables the DNS plugin for this network which if enabled, can perform container
 to container name resolution.
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="driver"></a>`driver`
+##### <a name="-podman--network--driver"></a>`driver`
 
 Data type: `Enum['bridge', 'macvlan']`
 
@@ -550,7 +566,7 @@ Driver to manage the network.
 
 Default value: `'bridge'`
 
-##### <a name="opts"></a>`opts`
+##### <a name="-podman--network--opts"></a>`opts`
 
 Data type: `Array[String]`
 
@@ -558,32 +574,32 @@ A list of driver specific options.
 
 Default value: `[]`
 
-##### <a name="gateway"></a>`gateway`
+##### <a name="-podman--network--gateway"></a>`gateway`
 
 Data type: `Optional[String]`
 
 Define the gateway for the network. Must also provide the subnet.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="internal"></a>`internal`
+##### <a name="-podman--network--internal"></a>`internal`
 
 Data type: `Boolean`
 
 Restrict external access of this network.
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="ip_range"></a>`ip_range`
+##### <a name="-podman--network--ip_range"></a>`ip_range`
 
 Data type: `Optional[String]`
 
 Allocate container IP from a range. The range must be a complete subnet and in
 CIDR notation.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="labels"></a>`labels`
+##### <a name="-podman--network--labels"></a>`labels`
 
 Data type: `Hash[String,String]`
 
@@ -591,23 +607,23 @@ A hash of metadata labels to set on the network.
 
 Default value: `{}`
 
-##### <a name="subnet"></a>`subnet`
+##### <a name="-podman--network--subnet"></a>`subnet`
 
 Data type: `Optional[String]`
 
 The subnet in CIDR notation
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="ipv6"></a>`ipv6`
+##### <a name="-podman--network--ipv6"></a>`ipv6`
 
 Data type: `Boolean`
 
 Enable IPv6 (dual-stack) networking.
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="user"></a>`user`
+##### <a name="-podman--network--user"></a>`user`
 
 Data type: `String`
 
@@ -617,9 +633,11 @@ the user must also be defined as a puppet resource that includes at least
 
 Default value: `''`
 
-### <a name="podmanpod"></a>`podman::pod`
+### <a name="podman--pod"></a>`podman::pod`
 
-Create a podman pod with defined flags
+Create a podman pod with defined flags and containers.
+
+* **Note** If the flags or container hashes change, the entire pod will be redeployed.
 
 #### Examples
 
@@ -628,8 +646,17 @@ Create a podman pod with defined flags
 ```puppet
 podman::pod { 'mypod':
   flags => {
-           label => 'use=test, app=wordpress',
-           }
+           label   => 'use=test, app=wordpress',
+           publish => '8443:443',
+  },
+  containers => {
+    wordpress => {
+      image => 'wordpress:php8.2-fpm-alpine',
+    },
+    haproxy => {
+      image => 'haproxy:latest',
+    },
+  },
 }
 ```
 
@@ -637,19 +664,21 @@ podman::pod { 'mypod':
 
 The following parameters are available in the `podman::pod` defined type:
 
-* [`ensure`](#ensure)
-* [`flags`](#flags)
-* [`user`](#user)
+* [`ensure`](#-podman--pod--ensure)
+* [`flags`](#-podman--pod--flags)
+* [`user`](#-podman--pod--user)
+* [`enable`](#-podman--pod--enable)
+* [`containers`](#-podman--pod--containers)
 
-##### <a name="ensure"></a>`ensure`
+##### <a name="-podman--pod--ensure"></a>`ensure`
 
-Data type: `String`
+Data type: `Enum['present', 'absent']`
 
 State of the resource, which must be either 'present' or 'absent'.
 
 Default value: `'present'`
 
-##### <a name="flags"></a>`flags`
+##### <a name="-podman--pod--flags"></a>`flags`
 
 Data type: `Hash`
 
@@ -659,7 +688,7 @@ pod name unless the 'name' flag is included in the hash of flags.
 
 Default value: `{}`
 
-##### <a name="user"></a>`user`
+##### <a name="-podman--pod--user"></a>`user`
 
 Data type: `String`
 
@@ -669,11 +698,29 @@ the user must also be defined as a Puppet resource and must include the
 
 Default value: `''`
 
-### <a name="podmanrootless"></a>`podman::rootless`
+##### <a name="-podman--pod--enable"></a>`enable`
+
+Data type: `Boolean`
+
+Start/enable the systemd service unit for the pod. Does not apply if no
+containers are declared for the pod because the systemd service unit will
+not be created without containers.
+
+Default value: `true`
+
+##### <a name="-podman--pod--containers"></a>`containers`
+
+Data type: `Hash`
+
+Hash of containers to add to the pod.
+
+Default value: `{}`
+
+### <a name="podman--rootless"></a>`podman::rootless`
 
 Enable a given user to run rootless podman containers as a systemd user service.
 
-### <a name="podmansubgid"></a>`podman::subgid`
+### <a name="podman--subgid"></a>`podman::subgid`
 
 Define an entry in the `/etc/subgid` file.
 
@@ -692,23 +739,23 @@ podman::subgid { 'myuser':
 
 The following parameters are available in the `podman::subgid` defined type:
 
-* [`subgid`](#subgid)
-* [`count`](#count)
-* [`order`](#order)
+* [`subgid`](#-podman--subgid--subgid)
+* [`count`](#-podman--subgid--count)
+* [`order`](#-podman--subgid--order)
 
-##### <a name="subgid"></a>`subgid`
+##### <a name="-podman--subgid--subgid"></a>`subgid`
 
 Data type: `Integer`
 
 Numerical subordinate group ID
 
-##### <a name="count"></a>`count`
+##### <a name="-podman--subgid--count"></a>`count`
 
 Data type: `Integer`
 
 Numerical subordinate group ID count
 
-##### <a name="order"></a>`order`
+##### <a name="-podman--subgid--order"></a>`order`
 
 Data type: `Integer`
 
@@ -716,7 +763,7 @@ Sequence number for concat fragments#
 
 Default value: `10`
 
-### <a name="podmansubuid"></a>`podman::subuid`
+### <a name="podman--subuid"></a>`podman::subuid`
 
 Manage entries in `/etc/subuid`
 
@@ -735,23 +782,23 @@ podman::subuid { 'namevar':
 
 The following parameters are available in the `podman::subuid` defined type:
 
-* [`subuid`](#subuid)
-* [`count`](#count)
-* [`order`](#order)
+* [`subuid`](#-podman--subuid--subuid)
+* [`count`](#-podman--subuid--count)
+* [`order`](#-podman--subuid--order)
 
-##### <a name="subuid"></a>`subuid`
+##### <a name="-podman--subuid--subuid"></a>`subuid`
 
 Data type: `Integer`
 
 Numerical subordinate user ID
 
-##### <a name="count"></a>`count`
+##### <a name="-podman--subuid--count"></a>`count`
 
 Data type: `Integer`
 
 Numerical subordinate user ID count
 
-##### <a name="order"></a>`order`
+##### <a name="-podman--subuid--order"></a>`order`
 
 Data type: `Integer`
 
@@ -759,7 +806,7 @@ Sequence number for concat fragments
 
 Default value: `10`
 
-### <a name="podmanvolume"></a>`podman::volume`
+### <a name="podman--volume"></a>`podman::volume`
 
 Create a podman volume with defined flags
 
@@ -779,11 +826,11 @@ podman::volume { 'myvolume':
 
 The following parameters are available in the `podman::volume` defined type:
 
-* [`ensure`](#ensure)
-* [`flags`](#flags)
-* [`user`](#user)
+* [`ensure`](#-podman--volume--ensure)
+* [`flags`](#-podman--volume--flags)
+* [`user`](#-podman--volume--user)
 
-##### <a name="ensure"></a>`ensure`
+##### <a name="-podman--volume--ensure"></a>`ensure`
 
 Data type: `String`
 
@@ -791,7 +838,7 @@ State of the resource must be either 'present' or 'absent'.
 
 Default value: `'present'`
 
-##### <a name="flags"></a>`flags`
+##### <a name="-podman--volume--flags"></a>`flags`
 
 Data type: `Hash`
 
@@ -802,7 +849,7 @@ Volume names are created based on the resoure title (namevar)
 
 Default value: `{}`
 
-##### <a name="user"></a>`user`
+##### <a name="-podman--volume--user"></a>`user`
 
 Data type: `String`
 

--- a/manifests/pod.pp
+++ b/manifests/pod.pp
@@ -1,4 +1,4 @@
-# @summary Create a podman pod with defined flags
+# @summary Create a podman pod with defined flags and containers.
 #
 # @param ensure
 #   State of the resource, which must be either 'present' or 'absent'.
@@ -13,26 +13,59 @@
 #   the user must also be defined as a Puppet resource and must include the
 #   'uid', 'gid', and 'home'
 #
+# @param enable
+#   Start/enable the systemd service unit for the pod. Does not apply if no
+#   containers are declared for the pod because the systemd service unit will
+#   not be created without containers.
+#
+# @param containers
+#   Hash of containers to add to the pod.
+#
 # @example
 #   podman::pod { 'mypod':
 #     flags => {
-#              label => 'use=test, app=wordpress',
-#              }
+#              label   => 'use=test, app=wordpress',
+#              publish => '8443:443',
+#     },
+#     containers => {
+#       wordpress => {
+#         image => 'wordpress:php8.2-fpm-alpine',
+#       },
+#       haproxy => {
+#         image => 'haproxy:latest',
+#       },
+#     },
 #   }
 #
+# @note If the flags or container hashes change, the entire pod will be redeployed.
+#
 define podman::pod (
-  String $ensure = 'present',
-  Hash $flags    = {},
-  String $user   = '',
+  Enum['present', 'absent'] $ensure = 'present',
+  Hash $flags                       = {},
+  String $user                      = '',
+  Boolean $enable                   = true,
+  Hash $containers                  = {},
 ) {
   require podman::install
 
+  # Add a label that is the sha256 of the flags and containers hashes
+  # This will be used to redeploy the pod if the flags or containers change
+  $pod_sha256 = sha256(inline_template('<%= @flags.to_s + @containers.to_s %>'))
+  if has_key($flags, 'label') {
+    $label = [] + $flags['label'] + "puppet_resource_sha256=${pod_sha256}"
+    $no_label = $flags.delete('label')
+  } else {
+    $label = "puppet_resource_sha256=${pod_sha256}"
+    $no_label = $flags
+  }
+
   # The resource name will be the pod name by default
-  $name_flags = merge({ name => $title }, $flags )
-  $pod_name = $name_flags['name']
+  $merged_flags = { name => $title, label => $label} + $no_label
+  $pod_name = $merged_flags['name']
+  $service_unit = "pod-${pod_name}.service"
 
   # Convert $flags hash to command arguments
-  $_flags = $name_flags.reduce('') |$mem, $flag| {
+  $_flags = $merged_flags.reduce('') |$mem, $flag| {
     if $flag[1] =~ String {
       "${mem} --${flag[0]} '${flag[1]}'"
     } elsif $flag[1] =~ Undef {
@@ -47,6 +80,9 @@ define podman::pod (
 
   if $user != '' {
     ensure_resource('podman::rootless', $user, {})
+    $systemctl = 'systemctl --user '
+    $service_unit_dir = "${User[$user]['home']}/.config/systemd/user"
+    $handle = "${user}-${pod_name}"
 
     # Set execution environment for the rootless user
     $exec_defaults = {
@@ -59,35 +95,176 @@ define podman::pod (
       cwd         => User[$user]['home'],
       provider    => 'shell',
       user        => $user,
-      require     => [
-        Podman::Rootless[$user],
-        Service['podman systemd-logind'],
-      ],
     }
+    $requires = [
+      Podman::Rootless[$user],
+      Service['podman systemd-logind'],
+    ]
+
+    # Reload systemd when service files are updated
+    ensure_resource('Exec', "podman_systemd_${user}_reload", {
+        path        => '/sbin:/usr/sbin:/bin:/usr/bin',
+        command     => "${systemctl} daemon-reload",
+        refreshonly => true,
+        environment => [
+          "HOME=${User[$user]['home']}",
+          "XDG_RUNTIME_DIR=/run/user/${User[$user]['uid']}",
+        ],
+        cwd         => User[$user]['home'],
+        provider    => 'shell',
+        user        => $user,
+      }
+    )
+    $podman_systemd_reload = "podman_systemd_${user}_reload"
+
   } else {
+    $systemctl = 'systemctl '
+    $service_unit_dir = '/etc/systemd/system/'
+    $handle = $pod_name
+
     $exec_defaults = {
       path        => '/sbin:/usr/sbin:/bin:/usr/bin',
       provider    => 'shell',
     }
+
+    # Reload systemd when service files are updated
+    ensure_resource('Exec', 'podman_systemd_reload', {
+        path        => '/sbin:/usr/sbin:/bin:/usr/bin',
+        command     => "${systemctl} daemon-reload",
+        refreshonly => true,
+      }
+    )
+    $requires = []
+    $podman_systemd_reload = 'podman_systemd_reload'
   }
 
-  case $ensure {
-    'present': {
-      exec { "create_pod_${pod_name}":
-        command => "podman pod create ${_flags}",
-        unless  => "podman pod exists ${pod_name}",
-        *       => $exec_defaults,
+  if $ensure == 'present' {
+    # Detect changes to the defined podman sha256 and re-deploy if needed
+    exec { "verify_pod_sha256_${handle}":
+      command => 'true',
+      unless  => @("END"/$L),
+        if podman pod exists ${pod_name}; then
+          saved_sha256=\$(podman pod inspect ${pod_name} --format '{{.Labels.puppet_resource_sha256}}')
+          test "\${saved_sha256}" = "${pod_sha256}"
+        fi
+        |END
+      require => $requires,
+      notify  => [
+        Exec["service_stop_pod_${handle}"],
+        Exec["service_remove_pod_${handle}"],
+        Exec["podman_remove_pod_${handle}"],
+      ],
+      *       => $exec_defaults,
+    }
+
+    # Stop pod service unit if pod changed
+    exec { "service_stop_pod_${handle}":
+      command     => "${systemctl} disable --now ${service_unit}",
+      onlyif      => @("END"/L),
+        ${systemctl} is-active ${service_unit} || \
+        ${systemctl} is-enabled ${service_unit}
+        |END
+      refreshonly => true,
+      *           => $exec_defaults,
+    }
+
+    # Remove pod service units if pod changed
+    exec { "service_remove_pod_${handle}":
+      command     => "rm -f ${service_unit} container-${pod_name}-*.service",
+      refreshonly => true,
+      require     => Exec["service_stop_pod_${handle}"],
+      before      => Exec["create_pod_${handle}"],
+      *           => $exec_defaults + {cwd => $service_unit_dir},
+    }
+
+    # Remove pod if pod changed
+    exec { "podman_remove_pod_${handle}":
+      command     => "podman pod rm --force ${pod_name}",
+      refreshonly => true,
+      require     => Exec["service_stop_pod_${handle}"],
+      before      => Exec["create_pod_${handle}"],
+      *           => $exec_defaults,
+    }
+
+    # Create pod
+    exec { "create_pod_${handle}":
+      command => "podman pod create ${_flags}",
+      unless  => "podman pod exists ${pod_name}",
+      *       => $exec_defaults,
+    }
+
+    # Set up systemd service units if pod has active containers
+    unless $containers.empty() {
+      # Declare the containers
+      $containers.each |$container, $params| {
+        podman::container { "${pod_name}-${container}":
+          user    => $user,
+          pod     => $pod_name,
+          require => Exec["create_pod_${handle}"],
+          notify  => Exec["podman_generate_service_${handle}"],
+          *       => $params
+        }
+      }
+
+      # Generate service units
+      exec { "podman_generate_service_${handle}":
+        command     => "podman generate systemd -f -n ${pod_name}",
+        refreshonly => true,
+        notify      => Exec[$podman_systemd_reload],
+        *           => $exec_defaults + {cwd => $service_unit_dir},
+      }
+
+      # Start/stop systemd service units.
+      if $enable {
+        exec { "service_pod_${handle}":
+          command => "${systemctl} enable --now ${service_unit}",
+          unless  => @("END"/L),
+            ${systemctl} is-active ${service_unit} && \
+            ${systemctl} is-enabled ${service_unit}
+            |END
+          require => Exec[$podman_systemd_reload],
+          *       => $exec_defaults,
+        }
+      } else {
+        exec { "service_pod_${handle}":
+          command => "${systemctl} disable --now ${service_unit}",
+          onlyif  => @("END"/L),
+            ${systemctl} is-active ${service_unit} || \
+            ${systemctl} is-enabled ${service_unit}
+            |END
+          require => Exec[$podman_systemd_reload],
+          *       => $exec_defaults,
+        }
       }
     }
-    'absent': {
-      exec { "remove_pod_${pod_name}":
-        command => "podman pod rm ${pod_name}",
-        unless  => "podman pod exists ${pod_name}; test $? -eq 1",
+  } else {
+    # Ensure pod is absent
+
+    # Stop pod service unit
+    exec { "service_stop_pod_${handle}":
+        command => "${systemctl} disable --now ${service_unit}",
+        onlyif  => @("END"/L),
+          ${systemctl} is-active ${service_unit} || \
+          ${systemctl} is-enabled ${service_unit}
+          |END
+        notify  => Exec["service_remove_pod_${handle}"],
         *       => $exec_defaults,
       }
+
+    # Remove pod service units
+    exec { "service_remove_pod_${handle}":
+      command     => "rm -f ${service_unit} container-${pod_name}-*.service",
+      refreshonly => true,
+      notify      => Exec[$podman_systemd_reload],
+      *           => $exec_defaults + {cwd => $service_unit_dir},
     }
-    default: {
-        fail('"ensure" must be "present" or "absent"')
+
+    # Remove pod
+    exec { "podman_remove_pod_${handle}":
+      command => "podman pod rm --force ${pod_name}",
+      onlyif  => "podman pod exists ${pod_name}",
+      require => Exec["service_stop_pod_${handle}"],
+      *       => $exec_defaults,
     }
   }
 }


### PR DESCRIPTION
Add support for deploying a pod with containers as a single unit by defining containers as part of the pod using a hash parameter on the pod resource. Systemd service units will be automatically created for both the pod and its containers. If there are any changes to the containers or flags hashes, the entire pod will be redeployed. If an individual container image is updated in the registry, then only the individual container will be redeployed (but the entire pod is restarted).

Note that the service units for the containers within a pod will be prefixed with the default "container-" instead of "podman-" due to how the service units are generated for the entire pod rather than for each container individually.