### PR TITLE
Avoid deprecated has_key function

### DIFF
--- a/manifests/container.pp
+++ b/manifests/container.pp
@@ -85,7 +85,7 @@ define podman::container (
   $flags_base64 = base64('encode', inline_template('<%= @flags.to_s %>'), strict)
 
   # Add the default name and a custom label using the base64 encoded flags
-  if has_key($flags, 'label') {
+  if 'label' in  $flags {
     $label = [] + $flags['label'] + "puppet_resource_flags=${flags_base64}"
     $no_label = $flags.delete('label')
   } else {

--- a/spec/defines/container_spec.rb
+++ b/spec/defines/container_spec.rb
@@ -14,6 +14,13 @@ describe 'podman::container' do
       let(:facts) { os_facts }
 
       it { is_expected.to compile.with_all_deps }
+      context "with flag['label'] set" do
+        let(:params) do
+          super().merge(flags: { label: 'a=b' })
+        end
+
+        it { is_expected.to compile.with_all_deps }
+      end
     end
   end
 end


### PR DESCRIPTION
The `has_key` function was removed with:

https://github.com/puppetlabs/puppetlabs-stdlib/pull/1319