### PR TITLE
Exclude root socket from socket_user customfact chunk

### DIFF
--- a/lib/facter/podman.rb
+++ b/lib/facter/podman.rb
@@ -39,6 +39,8 @@ Facter.add(:podman, type: :aggregate) do
         next unless File.exist?(path)
         uid = path.split(File::SEPARATOR)[3].to_i
 
+        next if uid == 0
+
         val['socket'] = {} if val['socket'].nil?
         val['socket'][Etc.getpwuid(uid)[:name]] = path
       end


### PR DESCRIPTION
If Podman user sockets have been enabled for root, calling `facter -p podman` in an interactive session as root will result into an error:

```
~# ll /run/user/0/podman/podman.sock
srw-rw---- 1 root root 0 Oct 20 22:19 /run/user/0/podman/podman.sock

~# facter -p podman
[2023-10-20 22:21:45.350548 ] ERROR Facter - Error while resolving custom fact fact='podman', resolution='<anonymous>': can't modify frozen String: "Cannot merge \"/run/podman/podman.sock\":String and \"/run/user/0/podman/podman.sock\":String"
```

This has been observed on Debian 11.8.

Excluding root from the `socker_user` chunk solves this issue and the fact works as expected, even for interactive logins of root:

```
~# facter -p podman
{
  socket => {
    Debian-gdm => "/run/user/118/podman/podman.sock",
    user => "/run/user/31257/podman/podman.sock",
    root => "/run/podman/podman.sock"
  },
  version => "3.0.1"
}
```