### PR TITLE
fix typo 'podmain' in spec & pp file

### DIFF
--- a/manifests/container.pp
+++ b/manifests/container.pp
@@ -48,7 +48,7 @@
 # @param ruby
 #   The absolute path to the ruby binary to use in scripts. The default path is
 #   '/opt/puppetlabs/puppet/bin/ruby' for Puppetlabs packaged puppet, and
-#   '/usr/bin/ruby' for all others. 
+#   '/usr/bin/ruby' for all others.
 #
 # @example
 #   podman::container { 'jenkins':
@@ -248,8 +248,8 @@ define podman::container (
         | END
 
       $onlyif_prc = @("END"/L)
-        test $(podmain container inspect --format json ${container_name} |\
-        ${_ruby} -rjson -e 'puts (JSON.parse(STDIN.read))[0]["State"]["Running"]') = 
+        test $(podman container inspect --format json ${container_name} |\
+        ${_ruby} -rjson -e 'puts (JSON.parse(STDIN.read))[0]["State"]["Running"]') =
         | END
 
       # Try to stop the container service, then the container directly

--- a/spec/defines/container_spec.rb
+++ b/spec/defines/container_spec.rb
@@ -105,11 +105,11 @@ describe 'podman::container' do
 
       remove_onlyif = if %r{^\/opt\/puppetlabs\/}.match?(os_facts[:ruby]['sitedir'])
                         <<-END.gsub(%r{^\s+\|}, '')
-          |test $(podmain container inspect --format json namevar |/opt/puppetlabs/puppet/bin/ruby -rjson -e 'puts (JSON.parse(STDIN.read))[0]["State"]["Running"]') =#{' '}
+          |test $(podman container inspect --format json namevar |/opt/puppetlabs/puppet/bin/ruby -rjson -e 'puts (JSON.parse(STDIN.read))[0]["State"]["Running"]') =#{' '}
         END
                       else
                         <<-END.gsub(%r{^\s+\|}, '')
-          |test $(podmain container inspect --format json namevar |/usr/bin/ruby -rjson -e 'puts (JSON.parse(STDIN.read))[0]["State"]["Running"]') =#{' '}
+          |test $(podman container inspect --format json namevar |/usr/bin/ruby -rjson -e 'puts (JSON.parse(STDIN.read))[0]["State"]["Running"]') =#{' '}
         END
                       end
 
@@ -806,7 +806,7 @@ describe 'podman::container' do
       it { is_expected.to contain_exec('verify_container_image_namevar').with_unless(unless_ruby) }
 
       onlyif_ruby = <<-END.gsub(%r{^\s+\|}, '')
-        |test $(podmain container inspect --format json namevar |/test/ing -rjson -e 'puts (JSON.parse(STDIN.read))[0]["State"]["Running"]') =#{' '}
+        |test $(podman container inspect --format json namevar |/test/ing -rjson -e 'puts (JSON.parse(STDIN.read))[0]["State"]["Running"]') =#{' '}
       END
 
       it { is_expected.to contain_exec('podman_remove_container_namevar').with_onlyif(onlyif_ruby) }
@@ -831,7 +831,7 @@ describe 'podman::container' do
       it { is_expected.to contain_exec('verify_container_image_namevar').with_unless(unless_ruby) }
 
       onlyif_ruby = <<-END.gsub(%r{^\s+\|}, '')
-        |test $(podmain container inspect --format json namevar |/test/ing -rjson -e 'puts (JSON.parse(STDIN.read))[0]["State"]["Running"]') =#{' '}
+        |test $(podman container inspect --format json namevar |/test/ing -rjson -e 'puts (JSON.parse(STDIN.read))[0]["State"]["Running"]') =#{' '}
       END
 
       it { is_expected.to contain_exec('podman_remove_container_namevar').with_onlyif(onlyif_ruby) }


### PR DESCRIPTION
In container.pp & some spec files, 'podman' was misspelled as 'podmain'.