### PR TITLE
fix: deployment failing due to `/etc/containers/systemd` dir missing

### DIFF
--- a/manifests/rootless.pp
+++ b/manifests/rootless.pp
@@ -21,6 +21,7 @@ define podman::rootless {
   # Create the user directory for rootless quadlet files
   ensure_resource(
     'File', [
+      '/etc/containers/systemd',
       '/etc/containers/systemd/users',
       "/etc/containers/systemd/users/${User[$name]['uid']}"
     ],

--- a/spec/defines/rootless_spec.rb
+++ b/spec/defines/rootless_spec.rb
@@ -30,6 +30,7 @@ describe 'podman::rootless' do
       end
 
       it do
+        is_expected.to contain_file('/etc/containers/systemd').only_with({ 'ensure' => 'directory', })
         is_expected.to contain_file('/etc/containers/systemd/users').only_with({ 'ensure' => 'directory', })
         is_expected.to contain_file('/etc/containers/systemd/users/3333').only_with({ 'ensure' => 'directory', })
       end


### PR DESCRIPTION
When we upgrade the module from `0.6.7` to `0.7.1` our deployment start to fails because the new code try to create
`/etc/containers/systemd/users` while `/etc/containers/systemd` doesn't exists.

This commit fix the issue be ensuring that `/etc/containers/systemd` also exists.