### PR TITLE
Resolve image name to ID before fetching digest to resolve false drift

### DIFF
--- a/manifests/container.pp
+++ b/manifests/container.pp
@@ -185,7 +185,7 @@ define podman::container (
           if podman container exists ${container_name}
             then
             image_name=\$(podman container inspect ${container_name} --format '{{.ImageName}}')
-            running_digest=\$(podman image inspect \${image_name} --format '{{.Digest}}')
+            running_digest=\$(podman image inspect $(podman image inspect \${image_name} --format='{{.ID}}') --format '{{.Digest}}')
             latest_digest=\$(skopeo inspect docker://${image} | \
               ${_ruby} -rjson -e 'puts (JSON.parse(STDIN.read))["Digest"]')
             [[ $? -ne 0 ]] && latest_digest=\$(skopeo inspect --no-creds docker://${image} | \

--- a/spec/defines/container_spec.rb
+++ b/spec/defines/container_spec.rb
@@ -50,7 +50,7 @@ describe 'podman::container' do
           |if podman container exists namevar
           |  then
           |  image_name=$(podman container inspect namevar --format '{{.ImageName}}')
-          |  running_digest=$(podman image inspect ${image_name} --format '{{.Digest}}')
+          |  running_digest=$(podman image inspect $(podman image inspect ${image_name} --format='{{.ID}}') --format '{{.Digest}}')
           |  latest_digest=$(skopeo inspect docker://registry:latest |     /opt/puppetlabs/puppet/bin/ruby -rjson -e 'puts (JSON.parse(STDIN.read))["Digest"]')
           |  [[ $? -ne 0 ]] && latest_digest=$(skopeo inspect --no-creds docker://registry:latest |     /opt/puppetlabs/puppet/bin/ruby -rjson -e 'puts (JSON.parse(STDIN.read))["Digest"]')
           |  test -z "${latest_digest}" && exit 0     # Do not update if unable to get latest digest
@@ -62,7 +62,7 @@ describe 'podman::container' do
           |if podman container exists namevar
           |  then
           |  image_name=$(podman container inspect namevar --format '{{.ImageName}}')
-          |  running_digest=$(podman image inspect ${image_name} --format '{{.Digest}}')
+          |  running_digest=$(podman image inspect $(podman image inspect ${image_name} --format='{{.ID}}') --format '{{.Digest}}')
           |  latest_digest=$(skopeo inspect docker://registry:latest |     /usr/bin/ruby -rjson -e 'puts (JSON.parse(STDIN.read))["Digest"]')
           |  [[ $? -ne 0 ]] && latest_digest=$(skopeo inspect --no-creds docker://registry:latest |     /usr/bin/ruby -rjson -e 'puts (JSON.parse(STDIN.read))["Digest"]')
           |  test -z "${latest_digest}" && exit 0     # Do not update if unable to get latest digest
@@ -203,7 +203,7 @@ describe 'podman::container' do
         |if podman container exists namevar
         |  then
         |  image_name=$(podman container inspect namevar --format '{{.ImageName}}')
-        |  running_digest=$(podman image inspect ${image_name} --format '{{.Digest}}')
+        |  running_digest=$(podman image inspect $(podman image inspect ${image_name} --format='{{.ID}}') --format '{{.Digest}}')
         |  latest_digest=$(skopeo inspect docker://testing:latest |     /opt/puppetlabs/puppet/bin/ruby -rjson -e 'puts (JSON.parse(STDIN.read))["Digest"]')
         |  [[ $? -ne 0 ]] && latest_digest=$(skopeo inspect --no-creds docker://testing:latest |     /opt/puppetlabs/puppet/bin/ruby -rjson -e 'puts (JSON.parse(STDIN.read))["Digest"]')
         |  test -z "${latest_digest}" && exit 0     # Do not update if unable to get latest digest
@@ -796,7 +796,7 @@ describe 'podman::container' do
         |if podman container exists namevar
         |  then
         |  image_name=$(podman container inspect namevar --format '{{.ImageName}}')
-        |  running_digest=$(podman image inspect ${image_name} --format '{{.Digest}}')
+        |  running_digest=$(podman image inspect $(podman image inspect ${image_name} --format='{{.ID}}') --format '{{.Digest}}')
         |  latest_digest=$(skopeo inspect docker://mandatory:latest |     /test/ing -rjson -e 'puts (JSON.parse(STDIN.read))["Digest"]')
         |  [[ $? -ne 0 ]] && latest_digest=$(skopeo inspect --no-creds docker://mandatory:latest |     /test/ing -rjson -e 'puts (JSON.parse(STDIN.read))["Digest"]')
         |  test -z "${latest_digest}" && exit 0     # Do not update if unable to get latest digest


### PR DESCRIPTION
EL9.5 ships podman v5 with skopeo 1.16 up from 1.14. The behaviour of how image digests are reported has changed, causing `podman::container` to consider needing to fetch a new image on every run and unwanted container restarts.

`podman image inspect --format='{{.Digest}}'` now returns different hashes depending on whether an image ID or a tag is given as argument.

Skopeo reports the image digest in the registry as if podman image inspect were called with the image ID.

This code resolves the given image name (which might be an ID or a Tag) into the ID before trying to fetch the digest. This prevents the false drift.

Fixes #91