### PR TITLE
fix: fixing the onlyi_prc condition

### DIFF
--- a/manifests/container.pp
+++ b/manifests/container.pp
@@ -249,7 +249,7 @@ define podman::container (
 
       $onlyif_prc = @("END"/L)
         test $(podman container inspect --format json ${container_name} |\
-        ${_ruby} -rjson -e 'puts (JSON.parse(STDIN.read))[0]["State"]["Running"]') = 
+        ${_ruby} -rjson -e 'puts (JSON.parse(STDIN.read))[0]["State"]["Running"]') = true
         | END
 
       # Try to stop the container service, then the container directly


### PR DESCRIPTION
Regarding: https://github.com/southalc/podman/issues/93

The check condition always return false and hence the container removal does not happen. Due to which, changes in flags do not go through.