### PR TITLE
Remove Bashism and update from private registry

### DIFF
--- a/manifests/container.pp
+++ b/manifests/container.pp
@@ -188,7 +188,7 @@ define podman::container (
             running_digest=\$(podman image inspect $(podman image inspect \${image_name} --format='{{.ID}}') --format '{{.Digest}}')
             latest_digest=\$(skopeo inspect docker://${image} | \
               ${_ruby} -rjson -e 'puts (JSON.parse(STDIN.read))["Digest"]')
-            test $? -ne 0 && latest_digest=\$(skopeo inspect --no-creds docker://${image} | \
+            test $? -ne 0 && latest_digest=\$(skopeo inspect docker://${image} | \
               ${_ruby} -rjson -e 'puts (JSON.parse(STDIN.read))["Digest"]')
             test -z "\${latest_digest}" && exit 0     # Do not update if unable to get latest digest
             test "\${running_digest}" = "\${latest_digest}"

--- a/manifests/container.pp
+++ b/manifests/container.pp
@@ -188,7 +188,7 @@ define podman::container (
             running_digest=\$(podman image inspect $(podman image inspect \${image_name} --format='{{.ID}}') --format '{{.Digest}}')
             latest_digest=\$(skopeo inspect docker://${image} | \
               ${_ruby} -rjson -e 'puts (JSON.parse(STDIN.read))["Digest"]')
-            [[ $? -ne 0 ]] && latest_digest=\$(skopeo inspect --no-creds docker://${image} | \
+            test $? -ne 0 && latest_digest=\$(skopeo inspect --no-creds docker://${image} | \
               ${_ruby} -rjson -e 'puts (JSON.parse(STDIN.read))["Digest"]')
             test -z "\${latest_digest}" && exit 0     # Do not update if unable to get latest digest
             test "\${running_digest}" = "\${latest_digest}"


### PR DESCRIPTION
On Ubuntu, `/bin/sh` points to `dash` be default since a while. It is used by the `shell` provider by the `exec` resource.

Dash does not have an alias `[[ = test`, so we use the latter directly.

Also, allow `skopeo` to use credentials provided in a config file, so we can `update => true` from private registries.