### PR TITLE
Allow user of USER while executing rootless actions

### DIFF
--- a/manifests/container.pp
+++ b/manifests/container.pp
@@ -131,7 +131,7 @@ define podman::container (
         path        => '/sbin:/usr/sbin:/bin:/usr/bin',
         command     => "${systemctl} daemon-reload",
         refreshonly => true,
-        environment => ["HOME=${User[$user]['home']}", "USER=$user",, "XDG_RUNTIME_DIR=/run/user/${User[$user]['uid']}"],
+        environment => ["HOME=${User[$user]['home']}", "USER=$user", "XDG_RUNTIME_DIR=/run/user/${User[$user]['uid']}"],
         cwd         => User[$user]['home'],
         provider    => 'shell',
         user        => $user,

--- a/manifests/container.pp
+++ b/manifests/container.pp
@@ -119,6 +119,7 @@ define podman::container (
         "HOME=${User[$user]['home']}",
         "XDG_RUNTIME_DIR=/run/user/${User[$user]['uid']}",
         "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${User[$user]['uid']}/bus",
+        "USER=$user",
       ],
     }
 
@@ -130,7 +131,7 @@ define podman::container (
         path        => '/sbin:/usr/sbin:/bin:/usr/bin',
         command     => "${systemctl} daemon-reload",
         refreshonly => true,
-        environment => ["HOME=${User[$user]['home']}", "XDG_RUNTIME_DIR=/run/user/${User[$user]['uid']}"],
+        environment => ["HOME=${User[$user]['home']}", "USER=$user",, "XDG_RUNTIME_DIR=/run/user/${User[$user]['uid']}"],
         cwd         => User[$user]['home'],
         provider    => 'shell',
         user        => $user,

--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -65,6 +65,7 @@ define podman::image (
         "HOME=${User[$user]['home']}",
         "XDG_RUNTIME_DIR=/run/user/${User[$user]['uid']}",
         "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${User[$user]['uid']}/bus",
+        "USER=$user",
       ] + $exec_env,
     }
   } else {

--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -118,6 +118,7 @@ define podman::network (
         "HOME=${User[$user]['home']}",
         "XDG_RUNTIME_DIR=/run/user/${User[$user]['uid']}",
         "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${User[$user]['uid']}/bus",
+        "USER=$user",
       ],
     }
   } else {

--- a/manifests/pod.pp
+++ b/manifests/pod.pp
@@ -57,6 +57,7 @@ define podman::pod (
         "HOME=${User[$user]['home']}",
         "XDG_RUNTIME_DIR=/run/user/${User[$user]['uid']}",
         "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${User[$user]['uid']}/bus",
+        "USER=$user",
       ],
     }
   } else {

--- a/manifests/rootless.pp
+++ b/manifests/rootless.pp
@@ -47,6 +47,7 @@ define podman::rootless {
         "HOME=${User[$name]['home']}",
         "XDG_RUNTIME_DIR=/run/user/${User[$name]['uid']}",
         "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${User[$name]['uid']}/bus",
+        "USER=$user",
       ],
       unless      => 'systemctl --user status podman.socket',
       require     => [

--- a/manifests/secret.pp
+++ b/manifests/secret.pp
@@ -96,6 +96,7 @@ define podman::secret (
       environment => [
         "HOME=${User[$user]['home']}",
         "XDG_RUNTIME_DIR=/run/user/${User[$user]['uid']}",
+        "USER=$user",
       ],
       cwd         => User[$user]['home'],
       provider    => 'shell',

--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -55,6 +55,7 @@ define podman::volume (
         "HOME=${User[$user]['home']}",
         "XDG_RUNTIME_DIR=/run/user/${User[$user]['uid']}",
         "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${User[$user]['uid']}/bus",
+        "USER=$user",
       ],
     }
   } else {


### PR DESCRIPTION
The main use case for this is setting rootless_volume_prefix to a human readable value rather than just UID, like /opt/podman/$USER.

