### PR TITLE
Use heredoc when creating a secret

### DIFF
--- a/manifests/quadlet.pp
+++ b/manifests/quadlet.pp
@@ -73,8 +73,8 @@ define podman::quadlet (
     # A rootless container will run as the defined user
     if $user == 'root' {
       $quadlet_file = "/etc/containers/systemd/${title}.${quadlet_type}"
-      ensure_resource('Systemd::Daemon_reload', 'podman', {})
-      $notify_systemd = Systemd::Daemon_reload['podman']
+      ensure_resource('Systemd::Daemon_reload', $title, {})
+      $notify_systemd = Systemd::Daemon_reload[$title]
       $requires = []
     } else {
       $quadlet_file = "/etc/containers/systemd/users/${User[$user]['uid']}/${title}.${quadlet_type}"

--- a/templates/set_secret_from_stdin.epp
+++ b/templates/set_secret_from_stdin.epp
@@ -3,4 +3,6 @@
   String[1] $title,
   String $flags,
 |-%>
-printf '<%= $secret %>' | podman secret create<%= "${flags} ${title}" %> -
+podman secret create<%= "${flags} ${title}" %> - <<'EOF'
+<%= $secret %>
+EOF


### PR DESCRIPTION
This ensures that the full content of the secret is not cut-off when the secret contains characters like single and double quotes.