### PR TITLE
remove require File[homedir] from rootless.pp

### DIFF
--- a/manifests/rootless.pp
+++ b/manifests/rootless.pp
@@ -14,7 +14,6 @@ define podman::rootless {
       owner   => $name,
       group   => "${User[$name]['gid']}",
       mode    => '0700',
-      require => File["${User[$name]['home']}"],
     }
   )
 


### PR DESCRIPTION
in most cases a users homedir is not managed with a File resource in puppet. it is managed by the User resource provider. The param  require => File["${User[$name]['home']}"], will usually fail. 

This commit removes the require and trusts that homedir exists. Much like we trust /etc/containers to already exist. 

Fixes [issue 58](https://github.com/southalc/podman/issues/58)