### PR TITLE
Add quadlet parameter to create with disabled service

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -737,6 +737,7 @@ The following parameters are available in the `podman::quadlet` defined type:
 * [`quadlet_type`](#-podman--quadlet--quadlet_type)
 * [`settings`](#-podman--quadlet--settings)
 * [`defaults`](#-podman--quadlet--defaults)
+* [`service_ensure`](#-podman--quadlet--service_ensure)
 
 ##### <a name="-podman--quadlet--ensure"></a>`ensure`
 
@@ -796,6 +797,15 @@ usage.  This allows running a container with nothing but an image defined.
 See the "data/common.yaml" file for default values.
 
 Default value: `{}`
+
+##### <a name="-podman--quadlet--service_ensure"></a>`service_ensure`
+
+Data type: `Enum['running', 'stopped']`
+
+The desired state of the systemd service. Valid values are 'running' or 'stopped'.
+
+Default value: `'running'`
+
 
 ### <a name="podman--rootless"></a>`podman::rootless`
 

--- a/spec/defines/quadlet_spec.rb
+++ b/spec/defines/quadlet_spec.rb
@@ -30,6 +30,52 @@ describe 'podman::quadlet' do
       end
     end
 
+    context "with root container on #{os} with service_ensure => 'running'" do
+      let(:facts) do
+        super().merge({ 'podman' => { 'version' => '4.4' } })
+      end
+      let(:params) { { 'service_ensure' => 'running', 'settings' => { 'Container' => { 'Image' => 'example.com/container1:latest', 'PublishPort' => '8080:8080', } } } }
+
+      it do
+        is_expected.to compile
+        is_expected.to contain_file('/etc/containers/systemd/container1.container').with(
+          {
+            'ensure' => 'present',
+            'notify' => 'Systemd::Daemon_reload[container1]',
+          },
+        )
+        is_expected.to contain_systemd__daemon_reload('container1')
+        is_expected.to contain_service('container1').only_with(
+          'ensure' => 'running',
+          'require' => 'Systemd::Daemon_reload[container1]',
+          'subscribe' => 'File[/etc/containers/systemd/container1.container]',
+        )
+      end
+    end
+
+    context "with root container on #{os} with service_ensure => 'stopped'" do
+      let(:facts) do
+        super().merge({ 'podman' => { 'version' => '4.4' } })
+      end
+      let(:params) { { 'service_ensure' => 'stopped', 'settings' => { 'Container' => { 'Image' => 'example.com/container1:latest', 'PublishPort' => '8080:8080', } } } }
+
+      it do
+        is_expected.to compile
+        is_expected.to contain_file('/etc/containers/systemd/container1.container').with(
+          {
+            'ensure' => 'present',
+            'notify' => 'Systemd::Daemon_reload[container1]',
+          },
+        )
+        is_expected.to contain_systemd__daemon_reload('container1')
+        is_expected.to contain_service('container1').only_with(
+          'ensure' => 'stopped',
+          'require' => 'Systemd::Daemon_reload[container1]',
+          'subscribe' => 'File[/etc/containers/systemd/container1.container]',
+        )
+      end
+    end
+
     context 'with unsupported podman version on #{os}' do
       let(:facts) do
         super().merge({ 'podman' => { 'version' => '3.4.4' } })
@@ -116,6 +162,96 @@ describe 'podman::quadlet' do
         is_expected.to contain_systemd__user_service('container1').with(
           {
             'ensure' => true,
+            'enable' => true,
+            'user' => 'testing',
+            'unit' => 'container1.service',
+            'require' => 'Systemd::Daemon_reload[podman_rootless_testing]',
+            'subscribe' => 'File[/etc/containers/systemd/users/3333/container1.container]',
+          },
+        )
+      end
+    end
+
+    context 'with user set to valid testing and service_ensure => running' do
+      let(:pre_condition) do
+        'include podman
+         # user & file needed by podman::rootless
+         user { "testing":
+           ensure  => "present",
+           gid     => 1111,
+           home    => "/home/testing",
+           uid     => 3333,
+         }
+         file { "/home/testing": }
+        '
+      end
+      let(:facts) do
+        super().merge({ 'podman' => { 'version' => '4.4.0' } })
+      end
+      let(:params) do
+        super().merge({ 'user' => 'testing', 'service_ensure' => 'running' })
+      end
+
+      it do
+        is_expected.to contain_podman__rootless('testing').only_with({})
+        is_expected.to contain_systemd__daemon_reload('podman_rootless_testing')
+        is_expected.to contain_file('/etc/containers/systemd/users')
+        is_expected.to contain_file('/etc/containers/systemd/users/3333')
+        is_expected.to contain_file('/etc/containers/systemd/users/3333/container1.container').with(
+          {
+            'ensure' => 'present',
+            'notify' => 'Systemd::Daemon_reload[podman_rootless_testing]',
+            'require' => '[Podman::Rootless[testing]{:name=>"testing"}]',
+          },
+        )
+        is_expected.to contain_systemd__user_service('container1').with(
+          {
+            'ensure' => true,
+            'enable' => true,
+            'user' => 'testing',
+            'unit' => 'container1.service',
+            'require' => 'Systemd::Daemon_reload[podman_rootless_testing]',
+            'subscribe' => 'File[/etc/containers/systemd/users/3333/container1.container]',
+          },
+        )
+      end
+    end
+
+    context 'with user set to valid testing and service_ensure => stopped' do
+      let(:pre_condition) do
+        'include podman
+         # user & file needed by podman::rootless
+         user { "testing":
+           ensure  => "present",
+           gid     => 1111,
+           home    => "/home/testing",
+           uid     => 3333,
+         }
+         file { "/home/testing": }
+        '
+      end
+      let(:facts) do
+        super().merge({ 'podman' => { 'version' => '4.4.0' } })
+      end
+      let(:params) do
+        super().merge({ 'user' => 'testing', 'service_ensure' => 'stopped' })
+      end
+
+      it do
+        is_expected.to contain_podman__rootless('testing').only_with({})
+        is_expected.to contain_systemd__daemon_reload('podman_rootless_testing')
+        is_expected.to contain_file('/etc/containers/systemd/users')
+        is_expected.to contain_file('/etc/containers/systemd/users/3333')
+        is_expected.to contain_file('/etc/containers/systemd/users/3333/container1.container').with(
+          {
+            'ensure' => 'present',
+            'notify' => 'Systemd::Daemon_reload[podman_rootless_testing]',
+            'require' => '[Podman::Rootless[testing]{:name=>"testing"}]',
+          },
+        )
+        is_expected.to contain_systemd__user_service('container1').with(
+          {
+            'ensure' => false,
             'enable' => true,
             'user' => 'testing',
             'unit' => 'container1.service',


### PR DESCRIPTION
As the example indicates, this is useful when wanting to create a quadlet that is not itself running but is instead the target of a systemd timer.