### PR TITLE
Ensure existing secret value is correctly evaluated

### DIFF
--- a/lib/puppet/type/podman_secret.rb
+++ b/lib/puppet/type/podman_secret.rb
@@ -2,6 +2,7 @@ Puppet::Type.newtype(:podman_secret) do
   desc 'Manage podman secrets'
 
   ensurable do
+    desc 'Manage the state of the secret'
     defaultvalues
     defaultto :present
   end


### PR DESCRIPTION
A warning can appear that will break comparison of the existing secret value:

```
WARN[0000] Using cgroups-v1 which is deprecated in favor of cgroups-v2 with Podman v5 and will be removed in a future version. Set environment variable `PODMAN_IGNORE_CGROUPSV1_WARNING` to hide this warning.
```

This needs to be disabled through an environment variable. The values also need to be properly compared to see if an update is needed and the existing value destroyed if update needs to happen.