### PR TITLE
Fix `uninitialized constant Puppet::Parameter::Boolean`

### DIFF
--- a/lib/puppet/type/podman_secret.rb
+++ b/lib/puppet/type/podman_secret.rb
@@ -1,3 +1,5 @@
+require 'puppet/parameter/boolean'
+
 Puppet::Type.newtype(:podman_secret) do
   desc 'Manage podman secrets'
 


### PR DESCRIPTION
On Puppet 7, resource type generation via `puppet generate types`, fails with the following error message:

```
Debug: Loading custom type 'podman_secret' in '.../modules/podman/lib/puppet/type/podman_secret.rb'.
Error: Failed to load custom type 'podman_secret' from '.../modules/podman/lib/puppet/type/podman_secret.rb': uninitialized constant Puppet::Parameter::Boolean
```

Adding an explicit require fixes this issue.

The require is also documented in the "old" OSS Puppet documentation: [Type development - Boolean parameters](https://www.puppet.com/docs/puppet/7/custom_types.html#tandp_parameters-boolean-params)