### PR TITLE
Add management of /etc/containers/registries.conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Add `registries_options` parameter to manage `/etc/containers/registries.conf`. Contributed by fasrc.
+
 ## Release 0.7.14
 - Properly handle idempotently removing image. Contributed by ehelms
 - Allow puppet/systemd 9.x. Contributed by evgeni

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ systemctl --user status podman-<container_name>
 ### containerd configuration
 
 This module also contains minimal support for editing the `containerd` configuration files that control some of the lower level
-settings for how containers are created. Currently, the only supported configuration files are `/etc/containers/storage.conf` and `/etc/containers/containers.conf`. You
-should be able to set any of the settings with those files using the `$podman::storage_options` and `$podman::containers_options` parameters respectively. For example (if using Hiera):
+settings for how containers are created. Currently, the only supported configuration files are `/etc/containers/storage.conf`, `/etc/containers/containers.conf`, and `/etc/containers/registries.conf`. You
+should be able to set any of the settings with those files using the `$podman::storage_options`, `$podman::containers_options`, and `$podman::registries_options` parameters respectively. For example (if using Hiera):
 
 ```yaml
 podman::storage_options:
@@ -119,7 +119,22 @@ podman::containers_options:
     cgroup_manager: '"cgroupfs"'
 ```
 
-**Note the use of double quotes inside single quotes above.** This is due to the way the [puppetlabs/inifile](https://github.com/puppetlabs/puppetlabs-inifile/) module works currently.
+```yaml
+podman::registries_options:
+  'unqualified-search-registries': '["registry.access.redhat.com", "registry.redhat.io", "docker.io"]'
+```
+
+**Note the use of double quotes inside single quotes above.** This will create the following in `/etc/containers/registries.conf`:
+
+```toml
+unqualified-search-registries = ["registry.access.redhat.com", "registry.redhat.io", "docker.io"]
+```
+
+The `registries_options` parameter allows you to configure any global or sectioned options in `/etc/containers/registries.conf`. The hash supports arbitrary key-value pairs:
+- **String/number values** become global TOML key-value pairs
+- **Hash values** become TOML sections (e.g., `[[registry]]`)
+
+A common use case is to set `unqualified-search-registries` to search specific registries for images. For example, setting it to `["docker.io"]` will mimic the default Docker daemon behavior, ensuring that `podman pull nginx` searches `docker.io` for the image, just like Docker does by default.
 
 ## Examples
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -88,6 +88,7 @@ The following parameters are available in the `podman` class:
 * [`nodocker`](#-podman--nodocker)
 * [`storage_options`](#-podman--storage_options)
 * [`containers_options`](#-podman--containers_options)
+* [`registries_options`](#-podman--registries_options)
 * [`rootless_users`](#-podman--rootless_users)
 * [`enable_api_socket`](#-podman--enable_api_socket)
 * [`manage_subuid`](#-podman--manage_subuid)
@@ -211,6 +212,43 @@ Default value: `{}`
 Data type: `Hash`
 
 A hash containing any containers options you wish to set in /etc/containers/containers.conf
+
+Default value: `{}`
+
+##### <a name="-podman--registries_options"></a>`registries_options`
+
+Data type: `Hash`
+
+A hash containing any registries options you wish to set in /etc/containers/registries.conf.
+Supports both global key-value pairs (string/number values) and sectioned configurations (hash values).
+
+**Global key-value pairs** - Any key with a non-Hash value becomes a global TOML option:
+```
+podman::registries_options:
+  'unqualified-search-registries': '["docker.io"]'
+  'short-name-mode': '"permissive"'
+```
+
+Generates:
+```toml
+unqualified-search-registries = ["docker.io"]
+short-name-mode = "permissive"
+```
+
+**Sectioned configurations** - Any key with a Hash value becomes a `[[section]]`:
+```
+podman::registries_options:
+  'registry':
+    location: '"registry.example.com"'
+    insecure: 'false'
+```
+
+Generates:
+```toml
+[[registry]]
+location = "registry.example.com"
+insecure = false
+```
 
 Default value: `{}`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,6 +43,9 @@
 # @param containers_options
 #   A hash containing any containers options you wish to set in /etc/containers/containers.conf
 #
+# @param registries_options
+#   A hash containing any registries options you wish to set in /etc/containers/registries.conf
+#
 # @param rootless_users
 #   An array of users to manage using [`podman::rootless`](#podmanrootless)
 #
@@ -90,6 +93,13 @@
 # @example Basic usage
 #   include podman
 #
+# @example Configure container registries to mimic docker daemon behavior
+#   class { 'podman':
+#     registries_options => {
+#       'unqualified-search-registries' => '["docker.io"]'
+#     }
+#   }
+#
 # @example A rootless Jenkins deployment using hiera
 #   podman::subid:
 #     jenkins:
@@ -129,6 +139,7 @@ class podman (
   Enum['absent', 'file']                            $nodocker                 = 'absent',
   Hash                                              $storage_options          = {},
   Hash                                              $containers_options       = {},
+  Hash                                              $registries_options     = {},
   Array                                             $rootless_users           = [],
   Boolean                                           $enable_api_socket        = false,
   Boolean                                           $manage_subuid            = false,

--- a/manifests/options.pp
+++ b/manifests/options.pp
@@ -19,4 +19,12 @@ class podman::options {
     }
     inifile::create_ini_settings($podman::containers_options, $containers_defaults)
   }
+
+  unless $podman::registries_options.empty {
+    file { '/etc/containers/registries.conf':
+      ensure  => file,
+      content => epp('podman/registries.conf.epp', { 'registries_options' => $podman::registries_options }),
+      mode    => '0644',
+    }
+  }
 }

--- a/templates/registries.conf.epp
+++ b/templates/registries.conf.epp
@@ -1,0 +1,18 @@
+<%- | Hash $registries_options | -%>
+# Managed by Puppet
+<%# Output global key-value pairs (non-Hash values) first -%>
+<% $registries_options.each |$key, $value| { -%>
+<% if $value !~ Hash { -%>
+<%= $key %> = <%= $value %>
+<% } -%>
+<% } -%>
+<%# Output sectioned configurations (Hash values) after global options -%>
+<% $registries_options.each |$key, $value| { -%>
+<% if $value =~ Hash { -%>
+
+[[<%= $key %>]]
+<% $value.each |$k, $v| { -%>
+<%= $k %> = <%= $v %>
+<% } -%>
+<% } -%>
+<% } -%>


### PR DESCRIPTION
Manages /etc/containers/registries.conf similar to how /etc/containers/containers.conf and /etc/containers/storage.conf are handled, though additionally supports global settings (e.g., `unqualified-search-registries =  ["docker.io"]`).

Note templates/registries.conf.epp was generated by Claude Sonnet 4.5. It seems to work in my cursory testing of a simple example, e.g.:

```
podman::registries_options:
  'unqualified-search-registries': '["docker.io"]'
  'short-name-mode': '"permissive"'
  'registry':
    location: '"registry.example.com"'
    insecure: 'false'
```

generated /etc/containers/registries.conf as:
```
# Managed by Puppet
unqualified-search-registries = ["docker.io"]
short-name-mode = "permissive"

[[registry]]
location = "registry.example.com"
insecure = false
```