### PR TITLE
Bump puppetlabs-concat upper bound to < 11.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 2.1.0 <= 10.0.0"
+      "version_requirement": ">= 2.1.0 < 11.0.0"
     },
     {
       "name": "puppetlabs/selinux_core",


### PR DESCRIPTION
## Summary

- Widen `puppetlabs-concat` dependency upper bound from `<= 10.0.0` to `< 11.0.0`

`puppetlabs-concat` 10.0.1 has been released, but the current upper bound (`<= 10.0.0`) excludes it. This causes dependency resolution failures in projects that depend on both this module and `puppetlabs-concat >= 10.0.1`.

For example, `librarian-puppet` fails when resolving dependencies for the [Foreman Installer](https://github.com/theforeman/foreman-installer) because `puppetlabs-apache` pulls in `concat 10.0.1` which conflicts with this module's `<= 10.0.0` constraint.

Widening to `< 11.0.0` allows all 10.x patch and minor releases while still guarding against a future major version bump.