### PR TITLE
Add systemd_version fact for rootless quadlet tests

### DIFF
--- a/spec/default_module_facts.yml
+++ b/spec/default_module_facts.yml
@@ -1,0 +1,2 @@
+---
+systemd_version: "252"


### PR DESCRIPTION
The systemd module v9.4.0 added a systemctl_user function that calls Integer($facts['systemd_version']). This is invoked when Systemd::Daemon_reload is created with a user parameter for rootless containers. Without the fact set, tests fail with "Value of type Undef cannot be converted to Integer".